### PR TITLE
Add fake train data mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
     - stage: Integration Testing
       install:
         - docker build . -t ftu
-        - docker run -d -p 5000:5000 ftu
+        - docker run -d -p 5000:5000 --env ftu_fake_it="true" ftu
         - pip install -r requirements/prod.txt
         - pip install -r requirements/dev.txt
       script:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This is a Flask learning project.
 The Flask application displays live train schedule information for UK train stations.  
 Autocomplete of the station name is via an AJAX call back to Flask.  
 Population of the live schedule information is via a websocket.    
-The live schedule information if provided by [transport api](https://www.transportapi.com/)
-If you want to run this application with live data you need to sign up for a free application id and key [here](https://www.transportapi.com/plans/). 
+The live schedule information if provided by [transport api](https://www.transportapi.com/)  
+If you want to run this application with live data you need to sign up for a free application id and key [here](https://www.transportapi.com/plans/).   
+If you just want to see the application run use fake data with the ftu_fake_it env variable.
 
 #### Setup
 
@@ -16,9 +17,14 @@ docker build
 docker build . -t ftu
 ```
 
-docker run
+docker run with live data
 ```console
 docker run -p 5000:5000 --env ftu_app_id=<app id> --env ftu_app_key=<app key> ftu  
+```
+
+docker run with fake data (no transport credentials required)
+```console
+docker run -p 5000:5000 --env ftu_fake_it="true" ftu  
 ```
 
 You will then be able to access the application at http://127.0.0.1:5000/

--- a/transport/app.py
+++ b/transport/app.py
@@ -111,4 +111,6 @@ if __name__ == '__main__':
                         level=os.getenv('ftu_log_level', 'DEBUG'))
     log.info('Starting transport UI')
     trie = create_trie()
+    if os.getenv('ftu_fake_it', False):
+        from transport.query import get_train_fake as get_train_live
     socket_io.run(app, host='0.0.0.0')

--- a/transport/query.py
+++ b/transport/query.py
@@ -2,6 +2,7 @@
 Interfaces with the transport api search methods.
 """
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 import json
 import logging
 import os
@@ -70,3 +71,25 @@ def _trim(query_result: str) -> List[Train]:
                       status=departure.get('status'))
         trains.append(train)
     return trains
+
+
+def get_train_fake(station: str) -> str:
+    """
+    Generates fake train data
+    :param station:
+    :return:
+    """
+    t = datetime.fromtimestamp(0)
+    delta = timedelta(hours=1)
+    trains = []
+    for i in range(12):
+        train = Train(aimed_departure_time=t.strftime('%H:%M'),
+                      expected_departure_time=t.strftime('%H:%M'),
+                      destination_name=f'{station} destination {i}',
+                      platform=str(i),
+                      operator_name=f'{station} operator',
+                      origin_name=f'{station} origin {i}',
+                      status=f'{"CANCELLED" if i % 3 == 0 else "ON TIME"}')
+        trains.append(train)
+        t += delta
+    return json.dumps(trains, indent=4, cls=TrainEncoder)


### PR DESCRIPTION
For testing in Travis fake train data can be used.
This saves checking in any credentials as well as keeping the transport
api application key within its daily limit.